### PR TITLE
Add seekable() method to ArchiveFileData

### DIFF
--- a/arpy.py
+++ b/arpy.py
@@ -171,6 +171,9 @@ class ArchiveFileData(object):
 			raise ArchiveAccessError("incorrect file position")
 		self.last_offset = offset
 
+	def seekable(self):
+		return True
+
 class Archive(object):
 	""" Archive object allowing reading of *.ar files """
 	def __init__(self, filename=None, fileobj=None):


### PR DESCRIPTION
I've got an **ar** file that contains a **tar.xz** file, and I'm using
Python 2.7.6 with the `backports.lzma` package to try to extract it:

```
import arpy
import backports.lzma as lzma
import tarfile
ar = arpy.Archive('at_3.1.13-2_amd64.deb')
ar.read_all_headers()
fileobj = lzma.open(ar.archived_files['data.tar.xz'])
tarfile.open(fileobj=fileobj)
```

This causes the following error:

```
AttributeError: 'ArchiveFileData' object has no attribute 'seekable'
```

I think `backports.lzma` is checking for a `seekable()` method because
Python 3 streams are `io` objects that have a `seekable()` method.
Really, it shouldn't assume this on Python 2. But since `arpy` also
supports Python 3, let's add a `seekable()` method to
`ArchiveFileData`.
