### PR TITLE
Extract calls

### DIFF
--- a/arpy.py
+++ b/arpy.py
@@ -454,18 +454,32 @@ class Archive(object):
 
 		raise ValueError("Can't look up file using type %s, expected bytes or ArchiveFileHeader" % (type(name),))
 
-	def extract(self, member: bytes, path: Optional[Union[str,bytes]]=None) -> None:
-		filename = os.path.basename(member)
+	def _resolve_extraction_path(self, member: bytes,
+			path: Optional[Union[str,bytes]]) -> bytes:
 		if path is None:
 			path = os.getcwd()
 
-		if isinstance(path, bytes):
-			filepath = os.path.join(path, filename)
-		else:
-			filepath = os.path.join(path.encode('utf-8'), filename)
+		if isinstance(path, str):
+			path = path.encode('utf-8')
+
+		normpath = os.path.abspath(path)
+		filepath = os.path.abspath(os.path.join(normpath, member))
+
+		if os.path.commonpath([normpath, filepath]) != normpath:
+			raise ExtractBreakoutAttempt("file %r would be extracted below specified path" % (member,))
+
+		return filepath
+
+	def extract(self, member: bytes, path: Optional[Union[str,bytes]]=None) -> None:
+		filepath = self._resolve_extraction_path(member, path)
 		buf_size = 8*1024
 
+		dirpath = os.path.dirname(filepath)
+		if dirpath:
+			os.makedirs(dirpath, exist_ok=True)
+
 		ar_member = self.open(member)
+		ar_member.seek(0)
 		with open(filepath, 'wb') as f:
 			while True:
 				buffer = ar_member.read(buf_size)
@@ -476,27 +490,13 @@ class Archive(object):
 	def extractall(self, path: Union[str, bytes], members: Optional[List[bytes]]=None) -> None:
 		self.read_all_headers()
 
-		normpath = os.path.normpath(path)
-		if isinstance(normpath, str):
-			normpath = normpath.encode('utf-8')
-
 		if members is None:
 			sources = list(self.archived_files.keys())
 		else:
 			sources = members
 
 		for member in sources:
-			member_dir = os.path.dirname(member)
-			member_name = os.path.basename(member)
-			filepath = os.path.join(normpath, member_dir, member_name)
-			norm_filepath = os.path.normpath(filepath)
-
-			if os.path.commonpath([normpath, norm_filepath]) != normpath:
-				raise ExtractBreakoutAttempt("file %r would be extracted below specified path" % (member,))
-
-			norm_dirpath = os.path.normpath(os.path.join(normpath, member_dir))
-			os.makedirs(norm_dirpath, exist_ok=True)
-			self.extract(member, norm_filepath)
+			self.extract(member, path)
 
 	def __enter__(self) -> "Archive":
 		return self

--- a/arpy.py
+++ b/arpy.py
@@ -60,6 +60,7 @@ You can also use context manager syntax with either the ar file or its contents.
 """
 
 import io
+import os
 import struct
 import os.path
 from typing import Optional, List, Dict, BinaryIO, cast, Union
@@ -84,6 +85,9 @@ class ArchiveFormatError(Exception):
 	pass
 class ArchiveAccessError(IOError):
 	""" Raised on problems with accessing the archived files """
+	pass
+class ExtractBreakoutAttempt(IOError):
+	""" Raised on files which would be extracted above specified path """
 	pass
 
 class ArchiveFileHeader(object):
@@ -449,6 +453,50 @@ class Archive(object):
 			return ArchiveFileData(ar_obj=self, header=name)
 
 		raise ValueError("Can't look up file using type %s, expected bytes or ArchiveFileHeader" % (type(name),))
+
+	def extract(self, member: bytes, path: Optional[Union[str,bytes]]=None) -> None:
+		filename = os.path.basename(member)
+		if path is None:
+			path = os.getcwd()
+
+		if isinstance(path, bytes):
+			filepath = os.path.join(path, filename)
+		else:
+			filepath = os.path.join(path.encode('utf-8'), filename)
+		buf_size = 8*1024
+
+		ar_member = self.open(member)
+		with open(filepath, 'wb') as f:
+			while True:
+				buffer = ar_member.read(buf_size)
+				if not len(buffer):
+					break
+				f.write(buffer)
+
+	def extractall(self, path: Union[str, bytes], members: Optional[List[bytes]]=None) -> None:
+		self.read_all_headers()
+
+		normpath = os.path.normpath(path)
+		if isinstance(normpath, str):
+			normpath = normpath.encode('utf-8')
+
+		if members is None:
+			sources = list(self.archived_files.keys())
+		else:
+			sources = members
+
+		for member in sources:
+			member_dir = os.path.dirname(member)
+			member_name = os.path.basename(member)
+			filepath = os.path.join(normpath, member_dir, member_name)
+			norm_filepath = os.path.normpath(filepath)
+
+			if os.path.commonpath([normpath, norm_filepath]) != normpath:
+				raise ExtractBreakoutAttempt("file %r would be extracted below specified path" % (member,))
+
+			norm_dirpath = os.path.normpath(os.path.join(normpath, member_dir))
+			os.makedirs(norm_dirpath, exist_ok=True)
+			self.extract(member, norm_filepath)
 
 	def __enter__(self) -> "Archive":
 		return self

--- a/test/test_contents.py
+++ b/test/test_contents.py
@@ -4,6 +4,27 @@ import os
 import io
 from unittest.mock import patch, mock_open, call
 
+
+def make_archive(entries):
+	archive = io.BytesIO()
+	archive.write(b"!<arch>\n")
+	for name, data in entries:
+		header = "{:<16}{:<12}{:<6}{:<6}{:<8}{:<10}`\n".format(
+			name.decode('ascii') + '/',
+			1364071329,
+			1000,
+			100,
+			"100644",
+			len(data),
+		).encode('ascii')
+		archive.write(header)
+		archive.write(data)
+		if len(data) % 2:
+			archive.write(b"\n")
+	archive.seek(0)
+	return archive
+
+
 class ArContents(unittest.TestCase):
 	def test_archive_contents(self):
 		ar = arpy.Archive(os.path.join(os.path.dirname(__file__), 'contents.ar'))
@@ -18,8 +39,11 @@ class ArContents(unittest.TestCase):
 		m = mock_open()
 		with arpy.Archive(os.path.join(os.path.dirname(__file__), 'contents.ar')) as ar:
 			with patch('arpy.open', m):
-				ar.extract(b'file1', '/foobar')
+				with patch('os.makedirs') as m_makedirs:
+					ar.extract(b'file1', '/foobar')
 
+		m_makedirs.assert_called_once_with(b'/foobar', exist_ok=True)
+		m.assert_called_once_with(b'/foobar/file1', 'wb')
 		m().write.assert_called_once_with(b'test_in_file_1\n')
 		m().__exit__.assert_called_once_with(None, None, None)
 
@@ -27,31 +51,55 @@ class ArContents(unittest.TestCase):
 		m = mock_open()
 		with arpy.Archive(os.path.join(os.path.dirname(__file__), 'contents.ar')) as ar:
 			with patch('arpy.open', m):
-				ar.extract(b'file1', b'/foobar')
+				with patch('os.makedirs') as m_makedirs:
+					ar.extract(b'file1', b'/foobar')
 
+		m_makedirs.assert_called_once_with(b'/foobar', exist_ok=True)
+		m.assert_called_once_with(b'/foobar/file1', 'wb')
 		m().write.assert_called_once_with(b'test_in_file_1\n')
 		m().__exit__.assert_called_once_with(None, None, None)
+
+	def test_extract_preserves_member_subdirectories(self):
+		m = mock_open()
+		with arpy.Archive(fileobj=make_archive([(b'dir/file', b'test')])) as ar:
+			with patch('arpy.open', m):
+				with patch('os.makedirs') as m_makedirs:
+					ar.extract(b'dir/file', '/foobar')
+
+		m_makedirs.assert_called_once_with(b'/foobar/dir', exist_ok=True)
+		m.assert_called_once_with(b'/foobar/dir/file', 'wb')
+		m().write.assert_called_once_with(b'test')
+
+	def test_extract_rewinds_member_before_copying(self):
+		m = mock_open()
+		with arpy.Archive(os.path.join(os.path.dirname(__file__), 'contents.ar')) as ar:
+			ar.open(b'file1').read(4)
+			with patch('arpy.open', m):
+				with patch('os.makedirs'):
+					ar.extract(b'file1', '/foobar')
+					ar.extract(b'file1', '/barbaz')
+
+		m().write.assert_has_calls([
+			call(b'test_in_file_1\n'),
+			call(b'test_in_file_1\n'),
+		])
 
 	def test_extractall(self):
 		with arpy.Archive(os.path.join(os.path.dirname(__file__), 'contents.ar')) as ar:
 			with patch.object(ar, 'extract') as m_extract:
-				with patch('os.makedirs') as m_makedirs:
-					ar.extractall('/foobar')
+				ar.extractall('/foobar')
 
 		m_extract.assert_has_calls([
-			call(b'file1', b'/foobar/file1'),
-			call(b'file2', b'/foobar/file2'),
+			call(b'file1', '/foobar'),
+			call(b'file2', '/foobar'),
 		], any_order=True)
-		m_makedirs.assert_called_with(b'/foobar', exist_ok=True)
 
 	def test_extractall2(self):
 		with arpy.Archive(os.path.join(os.path.dirname(__file__), 'contents.ar')) as ar:
 			with patch.object(ar, 'extract') as m_extract:
-				with patch('os.makedirs') as m_makedirs:
-					ar.extractall('/foobar', [b'file2'])
+				ar.extractall('/foobar', [b'file2'])
 
-		m_extract.assert_called_once_with(b'file2', b'/foobar/file2')
-		m_makedirs.assert_called_once_with(b'/foobar', exist_ok=True)
+		m_extract.assert_called_once_with(b'file2', '/foobar')
 
 class ArZipLike(unittest.TestCase):
 	def setUp(self):


### PR DESCRIPTION
Add the extract API.
These should be compatible with the zipfile module.

If `extractall` runs into situation where the file would be extracted below the specified path, it will throw an exception.