### PR TITLE
Better support MSVC .libs by using NULL char terminators when detected

### DIFF
--- a/arpy.py
+++ b/arpy.py
@@ -314,8 +314,14 @@ class Archive(object):
 		self.gnu_table = {}
 
 		position = 0
-		for filename in table_string.split(b"\n"):
-			self.gnu_table[position] = filename[:-1] # remove trailing '/'
+		if b"\x00" in table_string:
+			split_char = b"\x00"
+		else:
+			split_char = b"\n"
+		for filename in table_string.split(split_char):
+			self.gnu_table[position] = filename
+			if self.gnu_table[position].endswith(b"/"):
+				self.gnu_table[position] = self.gnu_table[position][:-1] # remove trailing '/'
 			position += len(filename) + 1
 
 	def __fix_name(self, header: ArchiveFileHeader) -> int:


### PR DESCRIPTION
MSVC likes to use NULL character terminators instead of
newlines (\n) for their listing, which causes parsing to not
work correctly, usually with this error:

    arpy.ArchiveFormatError: file references a name not present in the index

This is fixed by detecting NULL character usage and
using that delimiter accordingly.

Addresses: #16

Some very helpful inspiration that led to figuring this out:
 * http://wjradburn.com/software/
 * https://www.winehq.org/pipermail/wine-patches/2013-April/123863.html (winedump/lib.c)
 * https://substrate.dev/rustdocs/latest/object/pe/
 * http://hmelnov.icc.ru/geos/scripts/WWWBinV.dll/ShowR?COFF_LIB.rfi
 * http://www.textfiles.com/programming/FORMATS/lib.txt
 * https://www.ntcore.com/files/richsign.htm
 * http://bytepointer.com/resources/pietrek_lib_file_format.htm