### PR TITLE
Add support for 64-bit symbol lookup tables.

### DIFF
--- a/arpy.py
+++ b/arpy.py
@@ -99,7 +99,7 @@ class ArchiveFileHeader(object):
 
 		if name.startswith(b"#1/"):
 			self.type = HEADER_BSD
-		elif name.startswith(b"//"):
+		elif name.startswith(b"//") or name.startswith(b"/SYM64/"):
 			self.type = HEADER_GNU_TABLE
 		elif name.strip() == b"/":
 			self.type = HEADER_GNU_SYMBOLS


### PR DESCRIPTION
To overcome the 4 GiB file size limit some operating system like Solaris 11.2 and GNU use a variant lookup table. Instead of 32-bit integers, 64-bit integers are used in the symbol lookup tables. The string "/SYM64/" instead "/" is used as identifier for this table[¹](https://docs.oracle.com/cd/E36784_01/html/E36873/ar.h-3head.html).

A 32-bit archive symbol table has a zero length name, so ar_name contains the string "/" padded with 15 blank characters on the right. A 64-bit archive symbol table sets ar_name to the string "/SYM64/", padded with 9 blank characters to the right.

Without this fix errors like [these](https://github.com/onekey-sec/unblob/issues/767) are thrown by arpy.