### PR TITLE
ci: fix paths in CodeQL config

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,11 +1,10 @@
-ame: "CodeQL config"
+name: "CodeQL config"
 
 queries:
   - uses: security-and-quality
 
 paths:
-  - 'arpy.py'
-  - 'tests'
+  - '.'
 
 paths-ignore:
-  - 'tests/samples/**/*'
+  - 'test/samples/**/*'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,7 @@ jobs:
         run: uv run pyright .
 
   run_python_tests:
-    name: Run tests (Python)
+    name: Run tests (Python) (${{ matrix.python-version }})
     needs: [check_pre_commit, check_pyright]
     runs-on: ubuntu-latest
     strategy:
@@ -65,3 +65,13 @@ jobs:
 
       - name: Run pytest
         run: uv run pytest -vvv
+
+  run_python_tests_status:
+    name: Run tests (Python)
+    needs: [run_python_tests]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check matrix result
+        if: ${{ needs.run_python_tests.result != 'success' }}
+        run: exit 1


### PR DESCRIPTION
Test path is misconfigured.

https://github.com/onekey-sec/arpy/actions/runs/25556444151/job/75016565527

```
/opt/hostedtoolcache/CodeQL/2.25.4/x64/codeql/codeql database trace-command --index-traceless-dbs /home/runner/work/_temp/codeql_databases/python
  Running command in /home/runner/work/arpy/arpy: [/opt/hostedtoolcache/CodeQL/2.25.4/x64/codeql/python/tools/autobuild.sh]
...
"/opt/hostedtoolcache/CodeQL/2.25.4/x64/codeql/python/tools/python3src.zip/buildtools/index.py", line 131, in walk_dir
  [2026-05-08 12:49:41] [build-stderr] FileNotFoundError: [Errno 2] No such file or directory: 'tests'
  Error: 5-08 12:49:41] [ERROR] Spawned process exited abnormally (code 1; tried to run: [/opt/hostedtoolcache/CodeQL/2.25.4/x64/codeql/python/tools/autobuild.sh])
```
